### PR TITLE
debugging printToString() methods, called when verbose() is on

### DIFF
--- a/include/runtime/CompilerMSVC.h
+++ b/include/runtime/CompilerMSVC.h
@@ -121,6 +121,9 @@ public:
 		const std::vector<std::string>& 	getLinkerOptions() const { return mLinkerOptions; }
 		const std::vector<ci::fs::path>& 	getObjPaths() const { return mObjPaths; }
 
+		//! Method meant for debugging purposes to write a pretty string of all settings
+		std::string printToString() const;
+
 	protected:
 		friend class CompilerMsvc;
 		bool mVerbose;

--- a/src/runtime/CompilerMSVC.cpp
+++ b/src/runtime/CompilerMSVC.cpp
@@ -8,7 +8,7 @@
 #include "cinder/Log.h"
 #include "cinder/Utilities.h"
 
-#define RT_VERBOSE_DEFAULT 1
+#define RT_VERBOSE_DEFAULT 0
 
 using namespace std;
 using namespace ci;
@@ -317,11 +317,47 @@ std::string CompilerMsvc::BuildSettings::printToString() const
 {
 	stringstream str;
 
+	str << "link app objs: " << mLinkAppObjs << ", generate factory: " << mGenerateFactory << ", generate pch: " << mGeneratePch << ", use pch: " << mUsePch << "\n";
+	str << "precompiled header: " << mPrecompiledHeader << "\n";
+	str << "output path: " << mOutputPath << "\n";
 	str << "intermediate path: " << mIntermediatePath << "\n";
+	str << "pdb path: " << mPdbPath << "\n";
+	str << "module name: " << mModuleName << "\n";
 	str << "includes:\n";
 	for( const auto &include : mIncludes ) {
 		str << "\t- " << include << "\n";
 	}
+	str << "library paths:\n";
+	for( const auto &path : mLibraryPaths ) {
+		str << "\t- " << path << "\n";
+	}
+	str << "libraries:\n";
+	for( const auto &lib : mLibraries ) {
+		str << "\t- " << lib << "\n";
+	}
+	str << "additional sources:\n";
+	for( const auto &src : mAdditionalSources ) {
+		str << "\t- " << src << "\n";
+	}
+	str << "forced includes:\n";
+	for( const auto &include : mForcedIncludes ) {
+		str << "\t- " << include << "\n";
+	}
+	str << "preprocessor definitions: ";
+	for( const auto &ppDefine : mPpDefinitions ) {
+		str << ppDefine << " ";
+	}
+	str << endl;
+	str << "compiler options: ";
+	for( const auto &flag : mCompilerOptions ) {
+		str << flag << " ";
+	}
+	str << endl;
+	str << "linker options: ";
+	for( const auto &flag : mLinkerOptions ) {
+		str << flag << " ";
+	}
+	str << endl;
 
 	return str.str();
 }

--- a/src/runtime/CompilerMSVC.cpp
+++ b/src/runtime/CompilerMSVC.cpp
@@ -8,6 +8,8 @@
 #include "cinder/Log.h"
 #include "cinder/Utilities.h"
 
+#define RT_VERBOSE_DEFAULT 1
+
 using namespace std;
 using namespace ci;
 
@@ -66,6 +68,17 @@ namespace {
 	#else
 			platformToolset = "v120";
 	#endif
+
+		}
+
+		string printToString() const
+		{
+			stringstream str;
+
+			str << "projectPath: " << projectPath
+				<< "\n\t- configuration: " << configuration << ", platform: " << platform << ", platformTarget: " << platformTarget << ", platformToolset: " << platformToolset;
+
+			return str.str();
 		}
 
 		string configuration;
@@ -253,10 +266,16 @@ CompilerMsvc::BuildSettings::BuildSettings( bool defaultSettings )
 	.include( fs::absolute(  fs::path( __FILE__ ).parent_path().parent_path().parent_path() / "include" ) )
 	// app src folder
 	.include( "../src" )
+	.verbose( RT_VERBOSE_DEFAULT )
 	;
 
 	if( defaultSettings ) {
 		parseVcxproj( this, XmlTree( loadFile( getProjectConfiguration().projectPath ) ), getProjectConfiguration() );
+	}
+
+	if( mVerbose ) {
+		CI_LOG_I( "ProjectConfiguration: " << getProjectConfiguration().printToString() );
+		CI_LOG_I( "BuildSettings: " << printToString() );
 	}
 }
 
@@ -281,11 +300,30 @@ CompilerMsvc::BuildSettings::BuildSettings( const ci::fs::path &vcxProjPath )
 	//.linkerOption( "/INCREMENTAL:NO" )
 	.linkerOption( "/NOLOGO" ).linkerOption( "/NODEFAULTLIB:LIBCMT" ).linkerOption( "/NODEFAULTLIB:LIBCPMT" )
 	.define( "RT_COMPILED" )
+	.verbose( RT_VERBOSE_DEFAULT )
 
 	// cinder-runtime include 
 	.include( fs::absolute(  fs::path( __FILE__ ).parent_path().parent_path().parent_path() / "include" ) );
 
 	parseVcxproj( this, XmlTree( loadFile( getProjectConfiguration().projectPath ) ), getProjectConfiguration() );
+
+	if( mVerbose ) {
+		CI_LOG_I( "ProjectConfiguration: " << getProjectConfiguration().printToString() );
+		CI_LOG_I( "BuildSettings: " << printToString() );
+	}
+}
+
+std::string CompilerMsvc::BuildSettings::printToString() const
+{
+	stringstream str;
+
+	str << "intermediate path: " << mIntermediatePath << "\n";
+	str << "includes:\n";
+	for( const auto &include : mIncludes ) {
+		str << "\t- " << include << "\n";
+	}
+
+	return str.str();
 }
 
 CompilerMsvc::BuildSettings& CompilerMsvc::BuildSettings::include( const ci::fs::path &path )


### PR DESCRIPTION
Added some debug `printToString()` methods that will make it easy to dump current configurations to a log to help facilitate tracking stuff down. For now I'm just adjusting the `RT_VERBOSE_DEFAULT` flag at the top of CompilerMSVC as the `BuildSettings` are constructed from the stuff inside the magic new macros. Hopefully later on we'll have an easy way to set that at runtime from the outside but this is working now I think for basic debugging.

It's pretty verbose, we do levels, though it seems like for debugging purposes a lot of this can be useful. one thing I'm noticing is that the `BuildSettings` structure gets called 3 or 4 times at startup, and as I'm logging from there you get this dump each time. I imagine we can reduce that.

Output currently ends up looking like (for me, on the project I'm debugging):

```
|info   | runtime::CompilerMsvc::BuildSettings::BuildSettings[277] ProjectConfiguration: projectPath: D:\code\rte\mawork\test\Grapher\proj\vc2015\Grapher.vcxproj
	- configuration: Debug_Shared, platform: x64, platformTarget: x64, platformToolset: v140
|info   | runtime::CompilerMsvc::BuildSettings::BuildSettings[278] BuildSettings: link app objs: 1, generate factory: 1, generate pch: 0, use pch: 1
precompiled header: 
output path: 
intermediate path: D:\code\rte\mawork\test\Grapher\proj\vc2015\build\x64\Debug_Shared\v140\intermediate
pdb path: 
module name: 
includes:
	- D:\code\rte\mawork\test\Grapher\proj\vc2015\..\..\blocks\Cinder-Runtime\include
	- ..\src
	- $(REPO_PATH)\src
	- $(REPO_PATH)\lib\SpacePartitioning\include
	- $(REPO_PATH)\blocks\Cinder-Runtime\include
	- $(REPO_PATH)\blocks\mason\src
	- $(REPO_PATH)\blocks\mason\blocks\Cinder-View\src
	- $(REPO_PATH)\blocks\mason\blocks\Cinder-Profiler\src
	- $(CINDER_PATH)\include
library paths:
	- $(CINDER_PATH)\lib\msw\x64
	- $(CINDER_PATH)\lib\msw\x64\Debug_Shared\v140
libraries:
	- cinder.lib
	- OpenGL32.lib
	- $(REPO_PATH)\blocks\mason\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)\mason.lib
	- $(REPO_PATH)\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)\mawork.lib
additional sources:
forced includes:
preprocessor definitions: _DEBUG RT_COMPILED CINDER_SHARED WIN32 _WIN32_WINNT=0x0601 _WINDOWS NOMINMAX _DEBUG 
compiler options: /nologo /W3 /WX- /EHsc /RTC1 /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Gd /TP /Od /Zi /MDd 
linker options: /NOLOGO /NODEFAULTLIB:LIBCMT /NODEFAULTLIB:LIBCPMT 
```