### PR TITLE
Move most of macro'd news to template helper routines

### DIFF
--- a/include/runtime/CompilerMSVC.h
+++ b/include/runtime/CompilerMSVC.h
@@ -121,6 +121,9 @@ public:
 		const std::vector<std::string>& 	getLinkerOptions() const { return mLinkerOptions; }
 		const std::vector<ci::fs::path>& 	getObjPaths() const { return mObjPaths; }
 
+		//! Method meant for debugging purposes to write a pretty string of all settings
+		std::string printToString() const;
+
 	protected:
 		friend class CompilerMsvc;
 		bool mVerbose;

--- a/src/runtime/CompilerMSVC.cpp
+++ b/src/runtime/CompilerMSVC.cpp
@@ -8,7 +8,7 @@
 #include "cinder/Log.h"
 #include "cinder/Utilities.h"
 
-#define RT_VERBOSE_DEFAULT 1
+#define RT_VERBOSE_DEFAULT 0
 
 using namespace std;
 using namespace ci;
@@ -317,11 +317,47 @@ std::string CompilerMsvc::BuildSettings::printToString() const
 {
 	stringstream str;
 
+	str << "link app objs: " << mLinkAppObjs << ", generate factory: " << mGenerateFactory << ", generate pch: " << mGeneratePch << ", use pch: " << mUsePch << "\n";
+	str << "precompiled header: " << mPrecompiledHeader << "\n";
+	str << "output path: " << mOutputPath << "\n";
 	str << "intermediate path: " << mIntermediatePath << "\n";
+	str << "pdb path: " << mPdbPath << "\n";
+	str << "module name: " << mModuleName << "\n";
 	str << "includes:\n";
 	for( const auto &include : mIncludes ) {
 		str << "\t- " << include << "\n";
 	}
+	str << "library paths:\n";
+	for( const auto &path : mLibraryPaths ) {
+		str << "\t- " << path << "\n";
+	}
+	str << "libraries:\n";
+	for( const auto &lib : mLibraries ) {
+		str << "\t- " << lib << "\n";
+	}
+	str << "additional sources:\n";
+	for( const auto &src : mAdditionalSources ) {
+		str << "\t- " << src << "\n";
+	}
+	str << "forced includes:\n";
+	for( const auto &include : mForcedIncludes ) {
+		str << "\t- " << include << "\n";
+	}
+	str << "preprocessor definitions: ";
+	for( const auto &ppDefine : mPpDefinitions ) {
+		str << ppDefine << " ";
+	}
+	str << endl;
+	str << "compiler options: ";
+	for( const auto &flag : mCompilerOptions ) {
+		str << flag << " ";
+	}
+	str << endl;
+	str << "linker options: ";
+	for( const auto &flag : mLinkerOptions ) {
+		str << flag << " ";
+	}
+	str << endl;
 
 	return str.str();
 }

--- a/src/runtime/CompilerMSVC.cpp
+++ b/src/runtime/CompilerMSVC.cpp
@@ -8,6 +8,8 @@
 #include "cinder/Log.h"
 #include "cinder/Utilities.h"
 
+#define RT_VERBOSE_DEFAULT 1
+
 using namespace std;
 using namespace ci;
 
@@ -66,6 +68,17 @@ namespace {
 	#else
 			platformToolset = "v120";
 	#endif
+
+		}
+
+		string printToString() const
+		{
+			stringstream str;
+
+			str << "projectPath: " << projectPath
+				<< "\n\t- configuration: " << configuration << ", platform: " << platform << ", platformTarget: " << platformTarget << ", platformToolset: " << platformToolset;
+
+			return str.str();
 		}
 
 		string configuration;
@@ -253,10 +266,16 @@ CompilerMsvc::BuildSettings::BuildSettings( bool defaultSettings )
 	.include( fs::absolute(  fs::path( __FILE__ ).parent_path().parent_path().parent_path() / "include" ) )
 	// app src folder
 	.include( "../src" )
+	.verbose( RT_VERBOSE_DEFAULT )
 	;
 
 	if( defaultSettings ) {
 		parseVcxproj( this, XmlTree( loadFile( getProjectConfiguration().projectPath ) ), getProjectConfiguration() );
+	}
+
+	if( mVerbose ) {
+		CI_LOG_I( "ProjectConfiguration: " << getProjectConfiguration().printToString() );
+		CI_LOG_I( "BuildSettings: " << printToString() );
 	}
 }
 
@@ -281,11 +300,30 @@ CompilerMsvc::BuildSettings::BuildSettings( const ci::fs::path &vcxProjPath )
 	//.linkerOption( "/INCREMENTAL:NO" )
 	.linkerOption( "/NOLOGO" ).linkerOption( "/NODEFAULTLIB:LIBCMT" ).linkerOption( "/NODEFAULTLIB:LIBCPMT" )
 	.define( "RT_COMPILED" )
+	.verbose( RT_VERBOSE_DEFAULT )
 
 	// cinder-runtime include 
 	.include( fs::absolute(  fs::path( __FILE__ ).parent_path().parent_path().parent_path() / "include" ) );
 
 	parseVcxproj( this, XmlTree( loadFile( getProjectConfiguration().projectPath ) ), getProjectConfiguration() );
+
+	if( mVerbose ) {
+		CI_LOG_I( "ProjectConfiguration: " << getProjectConfiguration().printToString() );
+		CI_LOG_I( "BuildSettings: " << printToString() );
+	}
+}
+
+std::string CompilerMsvc::BuildSettings::printToString() const
+{
+	stringstream str;
+
+	str << "intermediate path: " << mIntermediatePath << "\n";
+	str << "includes:\n";
+	for( const auto &include : mIncludes ) {
+		str << "\t- " << include << "\n";
+	}
+
+	return str.str();
 }
 
 CompilerMsvc::BuildSettings& CompilerMsvc::BuildSettings::include( const ci::fs::path &path )


### PR DESCRIPTION
Note this is on top of #8, the only commit to pay attention to is 635a3a8.

This has two benefits, 1) it combines common code into a more legible format (out of macros into regular cpp) and 2) allows you to step through it in the debugger. I used this to debug why `BuildSettings` was getting created 3 times on each load (and therein parsing the .vcxproj file each time). This actually reduces it to two (it can be reduced to only 1 by removing the extra construction [here](https://github.com/simongeilfus/Cinder-Runtime/blob/043f421b9ee253de01a0a1be64fede0bfab4124d/include/runtime/ClassWatcher.h#L34)).

I think this code be even more condensed but seemed like a good start. I'm curious to know if the build times are any different, though I imagine it would only really affect initial startup, not runtime reloads, and that macros are not far off 1-level template methods. Haven't profiled, though.