### PR TITLE
Verbose improvements

### DIFF
--- a/include/runtime/ClassWatcher.h
+++ b/include/runtime/ClassWatcher.h
@@ -24,7 +24,7 @@ public:
 	static ClassWatcher& instance();
 	
 	//! Adds an instance to the ClassWatcher watch list
-	void watch( T* ptr, const std::string &name, const std::vector<ci::fs::path> &filePaths, const ci::fs::path &dllPath, const rt::Compiler::BuildSettings &settings = rt::Compiler::BuildSettings( true ) );
+	void watch( T* ptr, const std::string &name, const std::vector<ci::fs::path> &filePaths, const ci::fs::path &dllPath, rt::Compiler::BuildSettings settings = rt::Compiler::BuildSettings( true ) );
 	//! Removes an instance from ClassWatcher watch list
 	void unwatch( T* ptr );
 
@@ -139,9 +139,17 @@ typename ClassWatcher<T>& ClassWatcher<T>::instance()
 }
 
 template<class T>
-void ClassWatcher<T>::watch( T* ptr, const std::string &name, const std::vector<ci::fs::path> &filePaths, const ci::fs::path &dllPath, const rt::Compiler::BuildSettings &settings = rt::Compiler::BuildSettings( true ) )
+void ClassWatcher<T>::watch( T* ptr, const std::string &name, const std::vector<ci::fs::path> &filePaths, const ci::fs::path &dllPath, rt::Compiler::BuildSettings settings = rt::Compiler::BuildSettings( true ) )
 {
 	mInstances.push_back( static_cast<T*>( ptr ) );
+
+	if( settings.getModuleName().empty() ) {
+		settings.moduleName( name );
+	}
+
+	if( settings.isVerboseEnabled() ) {
+		Compiler::instance().debugLog( &settings );
+	}
 	
 	if( ! mModule ) {
 		mModule = std::make_unique<rt::Module>( dllPath );
@@ -157,9 +165,6 @@ void ClassWatcher<T>::watch( T* ptr, const std::string &name, const std::vector<
 				rt::Compiler::BuildSettings buildSettings = settings;
 				if( event.getFile().extension() == ".h" ) {
 					buildSettings.createPrecompiledHeader();
-				}
-				if( buildSettings.getModuleName().empty() ) {
-					buildSettings.moduleName( name );
 				}
 
 				// initiate the build

--- a/include/runtime/CompilerMSVC.h
+++ b/include/runtime/CompilerMSVC.h
@@ -164,6 +164,9 @@ public:
 	
 	//! Method meant for debugging purposes to write a pretty string of all settings
 	std::string printToString() const;
+	//! This logs Compiler, ProjectConfiguration, and BuildSettings to ci::log
+	void debugLog( BuildSettings *settings = nullptr ) const;
+
 protected:
 	std::string generateCompilerCommand( const ci::fs::path &sourcePath, const BuildSettings &settings, CompilationResult* result ) const;
 	std::string generateLinkerCommand( const ci::fs::path &sourcePath, const BuildSettings &settings, CompilationResult* result ) const;

--- a/include/runtime/CompilerMSVC.h
+++ b/include/runtime/CompilerMSVC.h
@@ -125,6 +125,8 @@ public:
 
 		const std::map<std::string, std::string>&	getUserMacros() const	{ return mUserMacros; };
 
+		bool isVerboseEnabled() const	{ return mVerbose; }
+
 		//! Method meant for debugging purposes to write a pretty string of all settings
 		std::string printToString() const;
 

--- a/src/runtime/CompilerMSVC.cpp
+++ b/src/runtime/CompilerMSVC.cpp
@@ -264,12 +264,12 @@ namespace {
 }
 
 CompilerMsvc::BuildSettings::BuildSettings()
-: mLinkAppObjs( true ), mGenerateFactory( true ), mGeneratePch( false ), mUsePch( true ), mConfiguration( getProjectConfiguration().configuration ), mPlatform( getProjectConfiguration().platform ), mPlatformToolset( getProjectConfiguration().platformToolset )
+: mVerbose( RT_VERBOSE_DEFAULT ), mLinkAppObjs( true ), mGenerateFactory( true ), mGeneratePch( false ), mUsePch( true ), mConfiguration( getProjectConfiguration().configuration ), mPlatform( getProjectConfiguration().platform ), mPlatformToolset( getProjectConfiguration().platformToolset )
 {
 }
 
 CompilerMsvc::BuildSettings::BuildSettings( bool defaultSettings )
-: mLinkAppObjs( true ), mGenerateFactory( true ), mGeneratePch( false ), mUsePch( true ), mConfiguration( getProjectConfiguration().configuration ), mPlatform( getProjectConfiguration().platform ), mPlatformToolset( getProjectConfiguration().platformToolset )
+: mVerbose( RT_VERBOSE_DEFAULT ), mLinkAppObjs( true ), mGenerateFactory( true ), mGeneratePch( false ), mUsePch( true ), mConfiguration( getProjectConfiguration().configuration ), mPlatform( getProjectConfiguration().platform ), mPlatformToolset( getProjectConfiguration().platformToolset )
 {
 	compilerOption( "/nologo" ).compilerOption( "/W3" ).compilerOption( "/WX-" ).compilerOption( "/EHsc" ).compilerOption( "/RTC1" ).compilerOption( "/GS" )
 	.compilerOption( "/fp:precise" ).compilerOption( "/Zc:wchar_t" ).compilerOption( "/Zc:forScope" ).compilerOption( "/Zc:inline" ).compilerOption( "/Gd" ).compilerOption( "/TP" )
@@ -291,7 +291,6 @@ CompilerMsvc::BuildSettings::BuildSettings( bool defaultSettings )
 	.include( fs::absolute(  fs::path( __FILE__ ).parent_path().parent_path().parent_path() / "include" ) )
 	// app src folder
 	.include( "../src" )
-	.verbose( RT_VERBOSE_DEFAULT )
 	;
 
 	if( defaultSettings ) {
@@ -305,7 +304,7 @@ CompilerMsvc::BuildSettings::BuildSettings( bool defaultSettings )
 }
 
 CompilerMsvc::BuildSettings::BuildSettings( const ci::fs::path &vcxProjPath )
-: mLinkAppObjs( true ), mGenerateFactory( true ), mGeneratePch( false ), mUsePch( true ), mConfiguration( getProjectConfiguration().configuration ), mPlatform( getProjectConfiguration().platform ), mPlatformToolset( getProjectConfiguration().platformToolset )
+: mVerbose( RT_VERBOSE_DEFAULT ), mLinkAppObjs( true ), mGenerateFactory( true ), mGeneratePch( false ), mUsePch( true ), mConfiguration( getProjectConfiguration().configuration ), mPlatform( getProjectConfiguration().platform ), mPlatformToolset( getProjectConfiguration().platformToolset )
 {
 	getProjectConfiguration().projectPath = vcxProjPath;
 	getProjectConfiguration().projectDir = vcxProjPath.parent_path();
@@ -325,7 +324,6 @@ CompilerMsvc::BuildSettings::BuildSettings( const ci::fs::path &vcxProjPath )
 	//.linkerOption( "/INCREMENTAL:NO" )
 	.linkerOption( "/NOLOGO" ).linkerOption( "/NODEFAULTLIB:LIBCMT" ).linkerOption( "/NODEFAULTLIB:LIBCPMT" )
 	.define( "RT_COMPILED" )
-	.verbose( RT_VERBOSE_DEFAULT )
 
 	// cinder-runtime include 
 	.include( fs::absolute(  fs::path( __FILE__ ).parent_path().parent_path().parent_path() / "include" ) );

--- a/src/runtime/CompilerMSVC.cpp
+++ b/src/runtime/CompilerMSVC.cpp
@@ -671,6 +671,10 @@ std::string CompilerMsvc::generateCompilerCommand( const ci::fs::path &sourcePat
 		result->getFilePaths().push_back( path );
 	}
 
+	if( settings.isVerboseEnabled() ) {
+		CI_LOG_I( "command:\n" << command );
+	}
+
 	return command;
 }
 std::string CompilerMsvc::generateLinkerCommand( const ci::fs::path &sourcePath, const BuildSettings &settings, CompilationResult* result ) const
@@ -742,7 +746,15 @@ std::string CompilerMsvc::generateLinkerCommand( const ci::fs::path &sourcePath,
 
 std::string CompilerMsvc::generateBuildCommand( const ci::fs::path &sourcePath, const BuildSettings &settings, CompilationResult* result ) const
 {
-	return generateCompilerCommand( sourcePath, settings, result ) + generateLinkerCommand( sourcePath, settings, result );
+	auto compilerCommand = generateCompilerCommand( sourcePath, settings, result );
+	auto linkerCommand = generateLinkerCommand( sourcePath, settings, result );
+
+	if( settings.isVerboseEnabled() ) {
+		CI_LOG_I( "compiler command:\n" << compilerCommand );
+		CI_LOG_I( "linker command:\n" << linkerCommand );
+	}
+
+	return compilerCommand + linkerCommand;
 }
 
 namespace {

--- a/src/runtime/CompilerMSVC.cpp
+++ b/src/runtime/CompilerMSVC.cpp
@@ -8,7 +8,7 @@
 #include "cinder/Log.h"
 #include "cinder/Utilities.h"
 
-#define RT_VERBOSE_DEFAULT 1
+#define RT_VERBOSE_DEFAULT 0
 
 using namespace std;
 using namespace ci;
@@ -296,11 +296,6 @@ CompilerMsvc::BuildSettings::BuildSettings( bool defaultSettings )
 	if( defaultSettings ) {
 		parseVcxproj( this, XmlTree( loadFile( getProjectConfiguration().projectPath ) ), getProjectConfiguration() );
 	}
-
-	if( mVerbose ) {
-		CI_LOG_I( "ProjectConfiguration: \n" << getProjectConfiguration().printToString() );
-		CI_LOG_I( "BuildSettings: \n" << printToString() );
-	}
 }
 
 CompilerMsvc::BuildSettings::BuildSettings( const ci::fs::path &vcxProjPath )
@@ -329,13 +324,8 @@ CompilerMsvc::BuildSettings::BuildSettings( const ci::fs::path &vcxProjPath )
 	.include( fs::absolute(  fs::path( __FILE__ ).parent_path().parent_path().parent_path() / "include" ) );
 
 	parseVcxproj( this, XmlTree( loadFile( getProjectConfiguration().projectPath ) ), getProjectConfiguration() );
-
-	if( mVerbose ) {
-		CI_LOG_I( "Compiler Settings: " << CompilerMsvc::instance().printToString() );
-		CI_LOG_I( "ProjectConfiguration: " << getProjectConfiguration().printToString() );
-		CI_LOG_I( "BuildSettings: " << printToString() );
-	}
 }
+
 std::string CompilerMsvc::printToString() const
 {
 	stringstream str;
@@ -345,6 +335,17 @@ std::string CompilerMsvc::printToString() const
 
 	return str.str();
 }
+
+void CompilerMsvc::debugLog( BuildSettings *settings ) const
+{
+	CI_LOG_I( "Compiler Settings: " << Compiler::instance().printToString() );
+	CI_LOG_I( "ProjectConfiguration: " << getProjectConfiguration().printToString() );
+
+	if( settings ) {
+		CI_LOG_I( "BuildSettings: " << settings->printToString() );
+	}
+}
+
 std::string CompilerMsvc::BuildSettings::printToString() const
 {
 	stringstream str;


### PR DESCRIPTION
This PR achieves two important things for verbose debugging:

1) You can set the `BuildSettings().verbose( true )` flag from user code. Beforehand, settings this wouldn't do any good since the logging was done at the end of BuildSettings constructor. I moved it to the `ClassWatcher::watch()` method for now, which also has the added benefit of showing the class type in the log pretty info
2) I set the module name before logging verbose mode.

With this, I usually enable verbose mode only for the module I'm trying to debug, which makes things easier to find in a complex setup.

There's also a commit in there (584d49a) that is cleaning up some of the path settings, which I did while debugging something or another. Should probably take a larger pass at that later but this felt like an improvement.